### PR TITLE
Refactor VoxelFields to use shape tuple

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -5,29 +5,29 @@ import voxelsss as vox
 
 def test_voxelFields_init():
     N = 10
-    sim = vox.VoxelFields(N, N, N)
-    assert (sim.Nx, sim.Ny, sim.Nz) == (N, N, N)
+    sim = vox.VoxelFields((N, N, N))
+    assert sim.shape == (N, N, N)
 
 def test_voxelFields_init_domain():
     N = 10
-    sim = vox.VoxelFields(N, N, N, (N,N,N))
+    sim = vox.VoxelFields((N, N, N), (N, N, N))
     assert (sim.domain_size, sim.spacing) == ((N, N, N),(1, 1, 1))
 
 def test_voxelFields_grid_cell_centered():
     Nx, Ny, Nz = 10, 5, 7
-    sim = vox.VoxelFields(Nx,Ny,Nz, (Nx,Ny,Nz))
+    sim = vox.VoxelFields((Nx, Ny, Nz), (Nx, Ny, Nz))
     (x,y,z) = sim.meshgrid()
     assert x[-1,0,0] == Nx-sim.spacing[0]/2
 
 def test_voxelFields_grid_staggered_x():
     Nx, Ny, Nz = 10, 5, 7
-    sim = vox.VoxelFields(Nx+1, Ny, Nz, (Nx,Ny,Nz), convention='staggered_x')
+    sim = vox.VoxelFields((Nx + 1, Ny, Nz), (Nx, Ny, Nz), convention='staggered_x')
     (x,y,z) = sim.meshgrid()
     assert (x[-1,0,0] == Nx) and (y[0,-1,0] == Ny-sim.spacing[1]/2)
 
 def test_voxelFields_init_fields():
     N = 10
-    sim = vox.VoxelFields(N, N, N, (N,N,N))
+    sim = vox.VoxelFields((N, N, N), (N, N, N))
     sim.add_field("c", 0.123*np.ones((N, N, N)))
 
     assert (sim.fields['c'][1,2,3], *sim.fields['c'].shape) == (0.123, N, N, N)

--- a/tests/test_rhs.py
+++ b/tests/test_rhs.py
@@ -21,9 +21,9 @@ def rhs_convergence_test(
 
     for i, p in enumerate(powers):
         if convention == 'cell_center':
-            vf = vox.VoxelFields(2**p, 2**p, 2**p, (1,1,1), convention=convention)
+            vf = vox.VoxelFields((2**p, 2**p, 2**p), (1, 1, 1), convention=convention)
         elif convention == 'staggered_x':
-            vf = vox.VoxelFields(2**p+1, 2**p, 2**p, (1,1,1), convention=convention)
+            vf = vox.VoxelFields((2**p + 1, 2**p, 2**p), (1, 1, 1), convention=convention)
         vf.precision = dtype
         grid = vf.meshgrid()
         init_data = init_fun(*grid)

--- a/tests/test_voxelgrid.py
+++ b/tests/test_voxelgrid.py
@@ -19,9 +19,9 @@ def grid_convergence_test(
 
     for i, p in enumerate(powers):
         if convention == 'cell_center':
-            vf = vox.VoxelFields(2**p, 2**p, 2**p, (1,1,1), convention=convention)
+            vf = vox.VoxelFields((2**p, 2**p, 2**p), (1, 1, 1), convention=convention)
         elif convention == 'staggered_x':
-            vf = vox.VoxelFields(2**p+1, 2**p, 2**p, (1,1,1), convention=convention)
+            vf = vox.VoxelFields((2**p + 1, 2**p, 2**p), (1, 1, 1), convention=convention)
         vf.precision = dtype
         grid = vf.meshgrid()
         init_data = init_fun(*grid)


### PR DESCRIPTION
## Summary
- refactor `VoxelFields` to accept a `(Nx, Ny, Nz)` shape
- keep backward-compatible properties `Nx`, `Ny`, `Nz`
- update field management methods to use `shape`
- adjust tests for new API